### PR TITLE
PORT: add libname to install() routine

### DIFF
--- a/plregtry.c
+++ b/plregtry.c
@@ -718,7 +718,7 @@ will makes these available in the calling context module.
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
 
 install_t
-install()
+install_plregtry()
 { init_constants();
 
   PL_register_foreign("reg_subkeys",	 2, pl_reg_subkeys,	0);


### PR DESCRIPTION
From this discussion: https://swi-prolog.discourse.group/t/static-executable-dstatic-extensions/5710/2 "the install function of a library must be called install_<libname> and the Prolog side must use use_foreign_library/1"